### PR TITLE
Few fixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,13 +72,13 @@ async def on_message(message):
 @tree.command(name="translate", description="Translate some text")
 @app_commands.describe(message="Message to translate")
 @app_commands.describe(language="Language to translate to (default is english)")
-async def Translator(interaction: discord.Interaction, message: str = None, language: str = None):
+async def Translator(interaction: discord.Interaction, message: str, language: str = None):
     await interaction.response.defer() # fix 404 no webhook bc apperently it takes over 3 seconds to respond (it doesn't it only takes like 500 ms)
     if language == None:
         language = "EN-US"
     language = language.upper()
     if message == None:
-        await interaction.followup.send(content=t.translate(lang=language.upper(), key="message.warning"))
+        await interaction.followup.send(content=t.translate(lang=language.upper(), key="message.somethingwrong"))
         return
     if language == "EN":
         language == "EN-US"

--- a/translations.py
+++ b/translations.py
@@ -1,7 +1,8 @@
 #TODO: add more languages
 en = {
     "translation.warning" : "Please use /translate for better compatibiliy.",
-    "message.warning" : "Please provide a message."
+    "message.warning" : "Please provide a message.",
+    "message.somethingwrong" : "Sorry, something went wrong. Please try again."
 }
     
 


### PR DESCRIPTION
make "message" argument required in /translate
- marking an argument as `str = None` makes it optional in discord
- removed `= None` to make it a required argument
- now `if message == None` can be used as a form of error handling, rather than a possibility

add "something went wrong" message to translations.py, use message for `if message == None` in /translate